### PR TITLE
[All-4743] Allow passing in existing access token to use with TV4 Play

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -92,6 +92,10 @@ class Tv4play(Service, OpenGraphThumbMixin):
         return match
 
     def _login(self):
+        existing_access_token = self.config.get("access_token")
+        if existing_access_token is not None:
+            return existing_access_token
+
         if self.config.get("username") is None or self.config.get("password") is None:
             return None
 

--- a/lib/svtplay_dl/utils/http.py
+++ b/lib/svtplay_dl/utils/http.py
@@ -46,8 +46,7 @@ class HTTP(Session):
         return res
 
     def split_header(self, headers):
-        # Split key and value by "#" instead of "=" to allow the value to contain "=".
-        return dict(x.split("#") for x in headers.split(";") if x)
+        return dict(x.split("=") for x in headers.split(";") if x)
 
 
 def download_thumbnails(output, config, urls):

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -162,6 +162,12 @@ def gen_parser(version="unknown"):
         default=False,
         help="only download video if audio and video is seperated",
     )
+    general.add_argument(
+        "--access-token",
+        dest="access_token",
+        default=None,
+        help="An access token to avoid repeated login.",
+    )
 
     quality = parser.add_argument_group("Quality")
     quality.add_argument(
@@ -367,6 +373,7 @@ def setup_defaults():
     options.set("filename", FILENAME)
     options.set("only_audio", False)
     options.set("only_video", False)
+    options.set("access_token", None)
     options.set("output_format", "mp4")
     options.set("get_all_subtitles", False)
     return _special_settings(options)
@@ -424,6 +431,7 @@ def parsertoconfig(config, parser):
     config.set("proxy", parser.proxy)
     config.set("only_audio", parser.only_audio)
     config.set("only_video", parser.only_video)
+    config.set("access_token", parser.access_token)
     config.set("output_format", parser.output_format)
     return _special_settings(config)
 


### PR DESCRIPTION
Add optional argument `--access-token` which will be used instead of trying to retrieve a new access token each time from TV4.